### PR TITLE
Some small changes to example vocabs

### DIFF
--- a/colors.ttl
+++ b/colors.ttl
@@ -1,16 +1,16 @@
-@prefix color: <https://example.org/color/> .
+@prefix colour: <https://example.org/colour/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-color: a skos:ConceptScheme ;
-    dct:title "Color Vocabulary"@en, "Farbvokabular"@de ;
+colour: a skos:ConceptScheme ;
+    dct:title "Colour Vocabulary"@en, "Farbvokabular"@de ;
     dct:creator "Hans Dampf"@de ;
     dct:created "2021-11-02"^^xsd:date ;
     dct:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
-    skos:hasTopConcept color:b0001 .
+    skos:hasTopConcept colour:violet .
 
-color:b0001 a skos:Concept ;
+colour:violet a skos:Concept ;
     skos:prefLabel "Violett"@de, "violet"@en ;
-    skos:altLabel "lila"@de, "purple"@en ;
-    skos:topConceptOf color: .
+    skos:altLabel "Lila"@de, "purple"@en ;
+    skos:topConceptOf colour: .

--- a/colors_with_hierarchy.ttl
+++ b/colors_with_hierarchy.ttl
@@ -1,25 +1,25 @@
-@prefix color: <https://example.org/color-with-hierarchy/> .
+@prefix colour: <https://example.org/colour-with-hierarchy/> .
 @prefix dct: <http://purl.org/dc/terms/> .
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-color: a skos:ConceptScheme ;
-    dct:title "Color vocabulary with hierarchy"@en, "Farbvokabular mit Hierarchie"@de ;
+colour: a skos:ConceptScheme ;
+    dct:title "Colour vocabulary with hierarchy"@en, "Farbvokabular mit Hierarchie"@de ;
     dct:creator "Hans Dampf"@de ;
     dct:created "2021-11-02"^^xsd:date ;
     dct:license <https://creativecommons.org/publicdomain/zero/1.0/> ;
-    skos:hasTopConcept color:b0001, color:b0002 .
+    skos:hasTopConcept colour:violet, colour:green .
 
-color:b0001 a skos:Concept ;
+colour:violet a skos:Concept ;
     skos:prefLabel "Violett"@de, "violet"@en ;
-    skos:altLabel "lila"@de, "purple"@en ;
-    skos:topConceptOf color: .
+    skos:altLabel "Lila"@de, "purple"@en ;
+    skos:topConceptOf colour: .
 
-color:b0002 a skos:Concept ;
+colour:green a skos:Concept ;
     skos:prefLabel "Green"@en, "Grün"@de ;
-    skos:narrower color:b0003 ;
-    skos:topConceptOf color: .
+    skos:narrower colour:grasgreen ;
+    skos:topConceptOf colour: .
     
-color:b0003 a skos:Concept ;
-    skos:prefLabel "Light green"@en, "Hellgrün"@de ;
-    skos:inScheme color: .
+colour:grassgreen a skos:Concept ;
+    skos:prefLabel "grass-green"@en, "Grasgrün"@de ;
+    skos:inScheme colour: .


### PR DESCRIPTION
I will use this repo in my IT2 master module at TH Köln and updated some smaller things:

- Use british spelling of "colour"
- Use speaking concept IDs
- Use gras-green instead of light green (which probably is a quite unnecessary change)