### PR TITLE
21 resolvable gh pages domain

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,6 +57,7 @@ jobs:
         with:
           files: |
             **/*.yml
+            **/*.yaml
           json: true
 
       - name: Set turtle file matrix
@@ -122,6 +123,7 @@ jobs:
           -v $(pwd)/public:/app/public
           -v $(pwd)/data:/app/data
           -v $(pwd)/.env:/app/.env
+          -v $(pwd)/config.yaml:/app/config.yaml
           -e GATSBY_RESPOSITORY_URL=https://github.com/$GITHUB_REPOSITORY
           skohub/skohub-vocabs-docker:latest
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,19 @@ If you want to reuse this repo and have your vocabulary automatically pushed und
 After that your vocabulary will be automatically published every time a push to this repo is made (sometimes it takes a little to see the changes, remember to do some hard refreshing).
 Any issues? Please open up a issue [here](https://github.com/skohub-io/skohub-docker-vocabs/issues)
 
+## Custom Domain
+
+If you want to host your vocabularies under your GitHub pages domain (so no W3 perma-id or purl.org redirect), you have to provide that domain in the [`config.yaml`](./config.yaml).
+
+Example:
+
+Your GitHub Pages domain is: `https://skohub-io.github.io/skohub-docker-vocabs/`
+Then provide `https://skohub-io.github.io/skohub-docker-vocabs/` as `custom_domain` in your `config.yaml`.
+
+The base of your concept scheme could then be something like: `https://skohub-io.github.io/skohub-docker-vocabs/colours/`
+
+Notice that this will apply to all your hosted vocabularies.
+
 ## Troubleshooting
 
 ### There is no `gh-pages` branch to select for GitHub Pages

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,39 @@
+---
+# see https://github.com/nextapps-de/flexsearch#tokenizer-prefix-search for options
+tokenizer: "full" # strict, forward, reverse, full
+custom_domain: ""
+fail_on_validation: true
+searchableAttributes:
+  - "prefLabel" # you should not delete this one
+  - "notation"
+  - "altLabel"
+  - "hiddenLabel"
+  - "example"
+  - "definition"
+ui:
+  title: "SkoHub Vocabs" # Title is mandatory
+  logo: "skohub-signet-color.svg" # Path
+  colors:
+    skoHubWhite: "rgb(255, 255, 255)"
+    skoHubDarkColor: "rgb(15, 85, 75)"
+    skoHubMiddleColor: "rgb(20, 150, 140)"
+    skoHubLightColor: "rgb(40, 200, 175)"
+    skoHubThinColor: "rgb(55, 250, 210)"
+    skoHubBlackColor: "rgb(5, 30, 30)"
+    skoHubAction: "rgb(230, 0, 125)"
+    skoHubNotice: "rgb(250, 180, 50)"
+    skoHubDarkGrey: "rgb(155, 155, 155)"
+    skoHubMiddleGrey: "rgb(200, 200, 200)"
+    skoHubLightGrey: "rgb(235, 235, 235)"
+  fonts:
+    regular:
+      font_family: "Ubuntu"
+      font_style: "normal"
+      font_weight: 400
+      name: "ubuntu-v20-latin-regular"
+    bold:
+      font_family: "Ubuntu"
+      font_style: "normal"
+      font_weight: 700
+      name: "ubuntu-v20-latin-700"
+


### PR DESCRIPTION
Adds config option to use GitHub Pages domain for resolvable links to vocabularies.