### PR TITLE
Remove imprint and data protection links from initial config

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ The base of your concept scheme could then be something like: `https://skohub-io
 
 Notice that this will apply to all your hosted vocabularies.
 
+## Further UI Customization
+
+If you want to customize your vocabulary UI further, check out the options provided by the `config.yaml`.
+See [default config](https://github.com/skohub-io/skohub-vocabs/blob/main/config.default.yaml) and [UI configuration documentation](https://github.com/skohub-io/skohub-vocabs?tab=readme-ov-file#ui)
+
 ## Troubleshooting
 
 ### There is no `gh-pages` branch to select for GitHub Pages

--- a/config.yaml
+++ b/config.yaml
@@ -36,4 +36,19 @@ ui:
       font_style: "normal"
       font_weight: 700
       name: "ubuntu-v20-latin-700"
+  footer:
+    links:
+      # It is strongly adviced to provide appropriate links for imprint and data protection and to then uncomment the following lines
+      #- title: "Impressum"
+      #  url: ""
+      #  target: "_blank"
+      #  rel: "noopener noreferrer"
+      #- title: "Datenschutz"
+      #  url: ""
+      #  target: "_blank"
+      #  rel: "noopener noreferrer"
+      - title: "© SkoHub"
+        url: "https://skohub.io"
+        target: "_blank"
+        rel: "noopener noreferrer"      
 


### PR DESCRIPTION
Addresses #42 

- removes "Impressum" and "Datenschutz" link from UI
- copies settings from default config of skohub-vocabs, commented out and with explanation
- refers to default config and README of skohub-vocabs